### PR TITLE
Update vite.config.js

### DIFF
--- a/vue/vue3/vite.config.js
+++ b/vue/vue3/vite.config.js
@@ -7,7 +7,7 @@ export default defineConfig({
     vue(),
     copy({
       targets: [
-        { src: './node_modules/libpag/lib/libpag.wasm', dest: process.env.NODE_ENV === 'production' ? 'dist/' : './' },
+        { src: './node_modules/libpag/lib/libpag.wasm', dest: process.env.NODE_ENV === 'production' ? 'dist/' : 'public/' },
       ],
       hook: process.env.NODE_ENV === 'production' ? 'writeBundle' : "buildStart",
     }),


### PR DESCRIPTION
When in `dev` mode, any files in `public` dir would serve as root path resource.